### PR TITLE
Update settings.xml

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,7 +4,7 @@
     <category label="32000">
         <setting id="general.theme" label="32001" type="labelenum" lvalues="32002|32003" default="32002" />
         <setting id="general.display_color" type="action" label="32005"
-                 action="RunScript(service.a4kSkips,action=color_picker)"
+                 action="RunScript(service.subskip,action=color_picker)"
                  default="[COLOR forestgreen]forestgreen[/COLOR]"/>
         <setting id="general.accent_color" label="32005" type="text" visible="false" default="forestgreen" />
         <setting id="general.use_a4ksubs" label="32004" type="bool" default="true" visible="System.HasAddon(service.subtitles.a4ksubtitles)" />


### PR DESCRIPTION
Resolves `error <general>: ExecuteAsync - Not executing non-existing script service.a4kSkips`

Add-on renamed but `settings.xml` missed the update--this broke the color picker in the Settings menu. Validated functionality of color picker after change.